### PR TITLE
58行目の「`Main` メソッドの右下」は「`Main` メソッドの真下」の誤記ではないでしょうか

### DIFF
--- a/docs/csharp/tutorials/console-teleprompter.md
+++ b/docs/csharp/tutorials/console-teleprompter.md
@@ -55,7 +55,7 @@ namespace TeleprompterConsole
 ## <a name="reading-and-echoing-the-file"></a>ファイルの読み取りとエコー
 最初に追加する機能は、テキスト ファイルを読み取り、そのテキストすべてをコンソールに表示するものです。 まず、テキスト ファイルを追加しましょう。 この[サンプル](https://github.com/dotnet/docs/tree/master/samples/csharp/getting-started/console-teleprompter)の GitHub リポジトリから、[sampleQuotes.txt](https://raw.githubusercontent.com/dotnet/docs/master/samples/csharp/getting-started/console-teleprompter/sampleQuotes.txt) ファイルをプロジェクト ディレクトリにコピーします。 これがアプリケーションのスクリプトとして機能します。
 
-次に、以下のメソッドを Program クラス (`Main` メソッドの右下) に追加します。
+次に、以下のメソッドを Program クラス (`Main` メソッドの真下) に追加します。
 
 ```csharp
 static IEnumerable<string> ReadFrom(string file)


### PR DESCRIPTION
原文は"right below the `Main` method"