### PR TITLE
Update access-modifiers.md

### DIFF
--- a/docs/csharp/language-reference/keywords/access-modifiers.md
+++ b/docs/csharp/language-reference/keywords/access-modifiers.md
@@ -51,9 +51,9 @@ ms.lasthandoff: 07/28/2017
   
  `protected`: コンテナーであるクラス、またはコンテナーであるクラスから派生した型にアクセスが制限されます。  
   
- `Internal`: 現在のアセンブリにアクセスが制限されます。  
+ `internal`: 現在のアセンブリにアクセスが制限されます。  
   
- [保護された内部](../../../csharp/programming-guide/classes-and-structs/access-modifiers.md): 現在のアセンブリ、またはコンテナーであるクラスから派生した型にアクセスが制限されます。  
+ [`protected internal`](../../../csharp/programming-guide/classes-and-structs/access-modifiers.md): 現在のアセンブリ、またはコンテナーであるクラスから派生した型にアクセスが制限されます。  
   
  `private`: コンテナーである型にアクセスが制限されます。  
   


### PR DESCRIPTION
protected internal が「保護された内部」に訳されていたので。

あと、この改行コードはいつ直りますか。