### PR TITLE
Update persistence-participants.md

### DIFF
--- a/docs/framework/windows-workflow-foundation/persistence-participants.md
+++ b/docs/framework/windows-workflow-foundation/persistence-participants.md
@@ -63,7 +63,7 @@ ms.lasthandoff: 12/02/2017
   
 -   単一ノード シナリオで、当該インスタンスがあるポイントで中止され、別のホスト ID を持つ新しい永続化プロバイダー インスタンスが作成されます。  
   
- ロックのタイムアウト値の既定値は 5 分です。呼び出したときに、別のタイムアウト値を指定できます <xref:System.ServiceModel.Persistence.PersistenceProvider.Load%2A>。  
+ ロックのタイムアウト値の既定値は 5 分です。 <xref:System.ServiceModel.Persistence.PersistenceProvider.Load%2A> の呼び出し時に、別のタイムアウト値を指定できます。  
   
 ## <a name="in-this-section"></a>このセクションの内容  
   


### PR DESCRIPTION
I found a bit unnatural sentence in Japanese language and would like to fix it. It would be appreciated if you would check this proposal.

**As-is** 呼び出したときに、別のタイムアウト値を指定できます Load。  
**To-be** Load の呼び出し時に、別のタイムアウト値を指定できます。

Best regards,