### PR TITLE
C# の仕様変更への追従漏れ

### DIFF
--- a/docs/csharp/language-reference/keywords/is.md
+++ b/docs/csharp/language-reference/keywords/is.md
@@ -92,7 +92,7 @@ C# 7 以降では、`is` および [switch](../../../csharp/language-reference/k
 
 - *expr* が、*type* インターフェイスを実装する型のインスタンスである。
 
-*exp* が `true` で `is` が `if` ステートメントと共に使用されている場合は *varname* への代入が行われ、そのローカル スコープは `if` ステートメント内に限定されます。
+*exp* が `true` で `is` が `if` ステートメントと共に使用されている場合は *varname* への代入が行われ、そのローカル スコープは `if` ステートメントを含むブロック内に限定されます。
 
 次の例では、`is` 型のパターンを使用して、型 <xref:System.IComparable.CompareTo(System.Object)?displayProperty=nameWithType> のメソッドの実装を提供します。
 


### PR DESCRIPTION
日本語だけでなく元の英文からの問題なのでこのPRが適切かどうかはわからないんですが…

C# 7.0 を作る際、一時期、`if (expr is type varname)` の `varname` 変数のスコープが `if` 内に限定されていた時期がありました。
このドキュメントはその時代に書かれたものだと思われます。
しかし、その後、C# 7.0 の正式リリースの時点では、`varname` 変数のスコープが1つ上のブロックに変わっています。ドキュメントの修正漏れではないでしょうか。