### PR TITLE
意味が逆になっている訳を修正する

### DIFF
--- a/docs/visual-basic/programming-guide/program-structure/coding-conventions.md
+++ b/docs/visual-basic/programming-guide/program-structure/coding-conventions.md
@@ -126,7 +126,7 @@ Microsoft は、ここで示すガイドラインに従ってサンプルおよ�
  `On Error Goto` は使用しないでください。  
   
 ### <a name="use-the-isnot-keyword"></a>IsNot キーワードの使用  
- `IsNot` の代わりに `Not...Is Nothing` キーワードを使用します。  
+ `Not...Is Nothing` の代わりに `IsNot` キーワードを使用します。  
   
 ### <a name="new-keyword"></a>New キーワード  
   


### PR DESCRIPTION
「`Not...Is Nothing` を使用する」ようになっていたので「`IsNot` を使用する」ようにする。