### PR TITLE
Fix title to match TOC

### DIFF
--- a/docs/csharp/language-reference/keywords/partial-method.md
+++ b/docs/csharp/language-reference/keywords/partial-method.md
@@ -1,5 +1,5 @@
 ---
-title: partial メソッド (C# リファレンス)
+title: partial (メソッド) (C# リファレンス)
 ms.date: 07/20/2015
 f1_keywords:
 - partialmethod_CSharpKeyword
@@ -13,7 +13,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 09/04/2018
 ms.locfileid: "43516370"
 ---
-# <a name="partial-method-c-reference"></a>partial メソッド (C# リファレンス)
+# <a name="partial-method-c-reference"></a>partial (メソッド) (C# リファレンス)
 
 部分メソッドには、部分型の一部に定義されたシグネチャ、および部分型の別の部分に定義された実装があります。 部分メソッドを使用すると、イベント ハンドラーと同じように、開発者が実装するかどうかを決定できるメソッド フックをクラス デザイナーで提供できます。 開発者が実装を指定しない場合、コンパイラはコンパイル時にシグネチャを削除します。 部分メソッドには次の条件が適用されます。
 


### PR DESCRIPTION
[TOC](https://github.com/dotnet/docs.ja-jp/blob/live/docs/csharp/language-reference/keywords/toc.md) の表現に合わせる