### PR TITLE
title: '～必要です'" → '～が必要です"

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/elseif-must-be-preceded-by-a-matching-if-or-elseif.md
+++ b/docs/visual-basic/language-reference/error-messages/elseif-must-be-preceded-by-a-matching-if-or-elseif.md
@@ -1,5 +1,5 @@
 ---
-title: "'#ElseIf' の前には、対応する '#If' または '#ElseIf' が必要です'"
+title: "'#ElseIf' の前には、対応する '#If' または '#ElseIf' が必要です"
 ms.date: 07/20/2015
 f1_keywords:
 - vbc30014


### PR DESCRIPTION
[#328](https://github.com/dotnet/docs.ja-jp/pull/329) is a mistake
title: '～必要です'" → '～が必要です"
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/elseif-must-be-preceded-by-a-matching-if-or-elseif