### PR TITLE
&lt;関数はfunctionname&gt; → '<functionname>'

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/functionname-is-not-declared-smart-device-visual-basic-compiler-error.md
+++ b/docs/visual-basic/language-reference/error-messages/functionname-is-not-declared-smart-device-visual-basic-compiler-error.md
@@ -1,5 +1,5 @@
 ---
-title: '&#39;&lt;関数は functionname&gt; &#39; (スマート デバイス Visual Basic コンパイラ エラー) が宣言されていません'
+title: ''<functionname>' は宣言されていません (スマート デバイスおよび Visual Basic コンパイラ エラー)'
 ms.date: 07/20/2015
 f1_keywords:
 - bc30766
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 05/04/2018
 ms.locfileid: "33584772"
 ---
-# <a name="39ltfunctionnamegt39-is-not-declared-smart-devicevisual-basic-compiler-error"></a>&#39;&lt;関数は functionname&gt; &#39; (Smart Device/visual Basic コンパイラ エラー) が宣言されていません
+# <a name="39ltfunctionnamegt39-is-not-declared-smart-devicevisual-basic-compiler-error"></a>'<functionname>' は宣言されていません (スマート デバイスおよび Visual Basic コンパイラ エラー)
 <`functionname`> が宣言されていません。 通常、ファイル I/O 機能は `Microsoft.VisualBasic` 名前空間で使用できますが、.NET Compact Framework のターゲット バージョンではサポートされていません。  
   
  **エラー ID:** BC30766  


### PR DESCRIPTION
'<functionname>' is not declared (Smart Device/Visual Basic Compiler Error)
&#39;&lt;関数は functionname&gt; &#39; (スマート デバイス Visual Basic コンパイラ エラー) が宣言されていません
 → '<functionname>' は宣言されていません (スマート デバイスおよび Visual Basic コンパイラ エラー)

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/functionname-is-not-declared-smart-device-visual-basic-compiler-error