### PR TITLE
再実装<型> → <type> の再実装

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/interfacename-membername-is-already-implemented-by-the-base-class.md
+++ b/docs/visual-basic/language-reference/error-messages/interfacename-membername-is-already-implemented-by-the-base-class.md
@@ -1,5 +1,5 @@
 ---
-title: '&#39;&lt;interfacename&gt;.&lt;membername&gt; &#39;は基本クラスによって既に実装されて&#39; &lt;baseclassname&gt;&#39;です。 再実装&lt;型&gt;と見なされます'
+title: ''<interfacename>.<membername>' は、基本クラス '<baseclassname>' によって既に実装されています。<type> の再実装と見なされます。'
 ms.date: 07/20/2015
 f1_keywords:
 - vbc42015
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 05/04/2018
 ms.locfileid: "33588971"
 ---
-# <a name="39ltinterfacenamegtltmembernamegt39-is-already-implemented-by-the-base-class-39ltbaseclassnamegt39-re-implementation-of-lttypegt-assumed"></a>&#39;&lt;interfacename&gt;.&lt;membername&gt; &#39;は基本クラスによって既に実装されて&#39; &lt;baseclassname&gt;&#39;です。 再実装&lt;型&gt;と見なされます
+# <a name="39ltinterfacenamegtltmembernamegt39-is-already-implemented-by-the-base-class-39ltbaseclassnamegt39-re-implementation-of-lttypegt-assumed"></a>'<interfacename>.<membername>' は、基本クラス '<baseclassname>' によって既に実装されています。<type> の再実装と見なされます。
 プロパティ、プロシージャ、または派生クラスでイベントを使用して、`Implements`句は、基底クラスで既に実装されているインターフェイス メンバーを指定します。  
   
  派生クラスでは、その基底クラスによって実装されているインターフェイス メンバーを再実装できます。 このことは、基底クラスの実装をオーバーライドすることとは異なります。 詳細については、次を参照してください。 [Implements](../../../visual-basic/language-reference/statements/implements-clause.md)です。  


### PR DESCRIPTION
‘<interfacename>.<membername>’ is already implemented by the base class '<baseclassname>'. Re-implementation of <type> assumed:

&#39;&lt;interfacename&gt;.&lt;membername&gt; &#39;は基本クラスによって既に実装されて&#39; &lt;baseclassname&gt;&#39;です。 再実装&lt;型&gt;と見なされます
 → '<interfacename>.<membername>' は、基本クラス '<baseclassname>' によって既に実装されています。<type> の再実装と見なされます。

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/interfacename-membername-is-already-implemented-by-the-base-class