### PR TITLE
明示的なフィールド。valキーワード → 明示的なフィールド:Val キーワード

### DIFF
--- a/docs/fsharp/language-reference/inheritance.md
+++ b/docs/fsharp/language-reference/inheritance.md
@@ -62,7 +62,7 @@ override [self-identifier].[method-name] [argument-list] = [method-body]
 
 [!code-fsharp[Main](../../../samples/snippets/fsharp/lang-ref-1/snippet2602.fs)]
 
-複数のコンス トラクターの場合、次のコードを使用していることができます。 派生クラスのコンス トラクターの最初の行は、`inherit`句と、フィールドで宣言された明示的なフィールドとして表示されます、`val`キーワード。 詳細については、次を参照してください。[明示的なフィールド。`val`キーワード](members/explicit-fields-the-val-keyword.md)します。
+複数のコンス トラクターの場合、次のコードを使用していることができます。 派生クラスのコンス トラクターの最初の行は、`inherit`句と、フィールドで宣言された明示的なフィールドとして表示されます、`val`キーワード。 詳細については、次を参照してください。[明示的なフィールド:`val`キーワード](members/explicit-fields-the-val-keyword.md)します。
 
 ```fsharp
 type BaseClass =


### PR DESCRIPTION
Explicit Fields: The val Keyword:
明示的なフィールド。valキーワード → 明示的なフィールド:Val キーワード
https://docs.microsoft.com/ja-jp/dotnet/fsharp/language-reference/inheritance

[明示的なフィールド:Val キーワード](https://docs.microsoft.com/ja-jp/dotnet/fsharp/language-reference/members/explicit-fields-the-val-keyword)