### PR TITLE
&#39;&lt;membername&gt; &#39; 、→ '<membername>' は、

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/membername-is-ambiguous-across-the-inherited-interfaces.md
+++ b/docs/visual-basic/language-reference/error-messages/membername-is-ambiguous-across-the-inherited-interfaces.md
@@ -1,5 +1,5 @@
 ---
-title: '&#39;&lt;membername&gt; &#39; 、継承インターフェイス間であいまいな&#39; &lt;interfacename1&gt; &#39;と&#39; &lt;interfacename2&gt;&#39;'
+title: ''<membername>' は、継承インターフェイス '<interfacename1>' および '<interfacename2>' 間ではあいまいです。'
 ms.date: 07/20/2015
 f1_keywords:
 - vbc30685
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 05/04/2018
 ms.locfileid: "33585302"
 ---
-# <a name="39ltmembernamegt39-is-ambiguous-across-the-inherited-interfaces-39ltinterfacename1gt39-and-39ltinterfacename2gt39"></a>&#39;&lt;membername&gt; &#39; 、継承インターフェイス間であいまいな&#39; &lt;interfacename1&gt; &#39;と&#39; &lt;interfacename2&gt;&#39;
+# <a name="39ltmembernamegt39-is-ambiguous-across-the-inherited-interfaces-39ltinterfacename1gt39-and-39ltinterfacename2gt39"></a>'<membername>' は、継承インターフェイス '<interfacename1>' および '<interfacename2>' 間ではあいまいです。
 インターフェイスは、同じ名前の 2 つ以上のメンバーを複数のインターフェイスから継承します。  
   
  **エラー ID:** BC30685  


### PR DESCRIPTION
'<membername>' is ambiguous across the inherited interfaces '<interfacename1>' and '<interfacename2>':
&#39;&lt;membername&gt; &#39; 、継承インターフェイス間であいまいな&#39; &lt;interfacename1&gt; &#39;と&#39; &lt;interfacename2&gt;&#39;
→ '<membername>' は、継承インターフェイス '<interfacename1>' および '<interfacename2>' 間ではあいまいです。

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/membername-is-ambiguous-across-the-inherited-interfaces