### PR TITLE
Visual Basic 2017 組 → Visual Basic 2017 のタプル

### DIFF
--- a/docs/fsharp/language-reference/tuples.md
+++ b/docs/fsharp/language-reference/tuples.md
@@ -130,7 +130,7 @@ let struct (newX, newY) = Example.AddOneToXAndY(struct (1, 2))
 
 ### <a name="compiled-form-of-struct-tuples"></a>構造体のタプルのコンパイル済みの形式
 
-構造体のタプル (たとえば、 `struct (x, y)`)、基本的に、参照の組から異なります。  コンパイル、<xref:System.ValueTuple>アリティ、または型パラメーターの数によってオーバー ロードされた型。  同じですが[c# 7.0 のタプル](../../csharp/tuples.md)と[Visual Basic のタプル](../../visual-basic/programming-guide/language-features/data-types/tuples.md)、双方向の相互運用とします。
+構造体のタプル (たとえば、 `struct (x, y)`)、基本的に、参照の組から異なります。  コンパイル、<xref:System.ValueTuple>アリティ、または型パラメーターの数によってオーバー ロードされた型。  同じですが[c# 7.0 のタプル](../../csharp/tuples.md)と[Visual Basic 2017 のタプル](../../visual-basic/programming-guide/language-features/data-types/tuples.md)、双方向の相互運用とします。
 
 ## <a name="see-also"></a>関連項目
 

--- a/docs/fsharp/language-reference/tuples.md
+++ b/docs/fsharp/language-reference/tuples.md
@@ -130,7 +130,7 @@ let struct (newX, newY) = Example.AddOneToXAndY(struct (1, 2))
 
 ### <a name="compiled-form-of-struct-tuples"></a>構造体のタプルのコンパイル済みの形式
 
-構造体のタプル (たとえば、 `struct (x, y)`)、基本的に、参照の組から異なります。  コンパイル、<xref:System.ValueTuple>アリティ、または型パラメーターの数によってオーバー ロードされた型。  同じですが[c# 7.0 のタプル](../../csharp/tuples.md)と[Visual Basic 2017 組](../../visual-basic/programming-guide/language-features/data-types/tuples.md)、双方向の相互運用とします。
+構造体のタプル (たとえば、 `struct (x, y)`)、基本的に、参照の組から異なります。  コンパイル、<xref:System.ValueTuple>アリティ、または型パラメーターの数によってオーバー ロードされた型。  同じですが[c# 7.0 のタプル](../../csharp/tuples.md)と[Visual Basic のタプル](../../visual-basic/programming-guide/language-features/data-types/tuples.md)、双方向の相互運用とします。
 
 ## <a name="see-also"></a>関連項目
 

--- a/docs/fsharp/language-reference/tuples.md
+++ b/docs/fsharp/language-reference/tuples.md
@@ -130,7 +130,7 @@ let struct (newX, newY) = Example.AddOneToXAndY(struct (1, 2))
 
 ### <a name="compiled-form-of-struct-tuples"></a>構造体のタプルのコンパイル済みの形式
 
-構造体のタプル (たとえば、 `struct (x, y)`)、基本的に、参照の組から異なります。  コンパイル、<xref:System.ValueTuple>アリティ、または型パラメーターの数によってオーバー ロードされた型。  同じですが[c# 7.0 のタプル](../../csharp/tuples.md)と[Visual Basic 2017 のタプル](../../visual-basic/programming-guide/language-features/data-types/tuples.md)、双方向の相互運用とします。
+構造体のタプル (たとえば、 `struct (x, y)`)は、参照タプルとは根本的に異なります。それらは<xref:System.ValueTuple>型にコンパイルされるか、アリティによってオーバーロードされるか、または型パラメーターの数になります。 これらは [c# 7.0 のタプル](../../csharp/tuples.md)および[Visual Basic 2017のタプル](../../visual-basic/programming-guide/language-features/data-types/tuples.md)と同等であり、双方向で相互運用できます。
 
 ## <a name="see-also"></a>関連項目
 


### PR DESCRIPTION
Visual Basic 2017 Tuples:
Visual Basic 2017 組 → Visual Basic のタプル
https://docs.microsoft.com/ja-jp/dotnet/fsharp/language-reference/tuples

[タプル (Visual Basic)](https://docs.microsoft.com/ja-jp/dotnet/visual-basic/programming-guide/language-features/data-types/tuples)