### PR TITLE
title:'.' は、基本クラス → '<interfacename>.<membername>' は、基本クラス

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/interfacename-membername-is-already-implemented-by-the-base-class.md
+++ b/docs/visual-basic/language-reference/error-messages/interfacename-membername-is-already-implemented-by-the-base-class.md
@@ -1,5 +1,5 @@
 ---
-title: "'<interfacename>.<membername>' は、基本クラス '<baseclassname>' によって既に実装されています。&lt;&gt;&lt;&gt;&lt;&gt; <type> の再実装と見なされます。&lt;&gt;"
+title: "'<interfacename>.<membername>' は、基本クラス '<baseclassname>' によって既に実装されています。<type> の再実装と見なされます。"
 ms.date: 07/20/2015
 f1_keywords:
 - vbc42015


### PR DESCRIPTION
'.' は、基本クラス '' によって既に実装されています。<><><> の再実装と見なされます。<>
 → '<interfacename>.<membername>' は、基本クラス '<baseclassname>' によって既に実装されています。<type> の再実装と見なされます。

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/interfacename-membername-is-already-implemented-by-the-base-class