### PR TITLE
<型> の再実装 → <type> の再実装

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/interfacename-membername-is-already-implemented-by-the-base-class.md
+++ b/docs/visual-basic/language-reference/error-messages/interfacename-membername-is-already-implemented-by-the-base-class.md
@@ -1,5 +1,5 @@
 ---
-title: "'<interfacename>.<membername>'は、既に基本クラスによって実装されて'<baseclassname>'。 再実装<type>と見なされます"
+title: "'<interfacename>.<membername>' は、基本クラス '<baseclassname>' によって既に実装されています。<type> の再実装と見なされます。"
 ms.date: 07/20/2015
 f1_keywords:
 - vbc42015
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 01/30/2019
 ms.locfileid: "55264152"
 ---
-# <a name="interfacenamemembername-is-already-implemented-by-the-base-class-baseclassname-re-implementation-of-type-assumed"></a>'\<interfacename >。\<membername >' は、基底クラスによって既に実装されて\<baseclassname >'。 再実装\<型 > と見なされます
+# <a name="interfacenamemembername-is-already-implemented-by-the-base-class-baseclassname-re-implementation-of-type-assumed"></a>'<interfacename>.<membername>' は、基本クラス '<baseclassname>' によって既に実装されています。<type> の再実装と見なされます。
 プロパティ、プロシージャ、または派生クラスでイベントを使用して、`Implements`句は既に基本クラスで実装されているインターフェイス メンバーを指定します。  
   
  派生クラスでは、その基底クラスによって実装されているインターフェイス メンバーを再実装できます。 このことは、基底クラスの実装をオーバーライドすることとは異なります。 詳細については、「 [Implements](../../../visual-basic/language-reference/statements/implements-clause.md)」を参照してください。  


### PR DESCRIPTION
'<interfacename>.<membername>' is already implemented by the base class '<baseclassname>'. Re-implementation of <type> assumed:
'<interfacename >。<membername >' は、基底クラスによって既に実装されて<baseclassname >'。 再実装<型 > と見なされます
 → '<interfacename>.<membername>' は、基本クラス '<baseclassname>' によって既に実装されています。<type> の再実装と見なされます。

Same #361

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/interfacename-membername-is-already-implemented-by-the-base-class