### PR TITLE
あいまいな<interfacename1 >' と'<interfacename2 >' →  '<interfacename1>' およ…

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/membername-is-ambiguous-across-the-inherited-interfaces.md
+++ b/docs/visual-basic/language-reference/error-messages/membername-is-ambiguous-across-the-inherited-interfaces.md
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 01/30/2019
 ms.locfileid: "55264995"
 ---
-# <a name="membername-is-ambiguous-across-the-inherited-interfaces-interfacename1-and-interfacename2"></a>'\<membername >' は継承されたインターフェイスの間であいまいな\<interfacename1 >' と'\<interfacename2 >'
+# <a name="membername-is-ambiguous-across-the-inherited-interfaces-interfacename1-and-interfacename2"></a>'<membername>' は、継承インターフェイス '<interfacename1>' および '<interfacename2>' 間ではあいまいです。
 インターフェイスは、複数のインターフェイスから同じ名前の 2 つ以上のメンバーを継承します。  
   
  **エラー ID:** BC30685  


### PR DESCRIPTION
…び '<interfacename2>' 間ではあいまいです。

'<membername>' is ambiguous across the inherited interfaces '<interfacename1>' and '<interfacename2>':
\<membername >' は継承されたインターフェイスの間であいまいな\<interfacename1 >' と'\<interfacename2 >
 → '<membername>' は、継承インターフェイス '<interfacename1>' および '<interfacename2>' 間ではあいまいです。

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/membername-is-ambiguous-across-the-inherited-interfaces