### PR TITLE
'<variablename>' のローカル変数またはパラメーターではないと、 → '<variablename>' はローカル変数または…

### DIFF
--- a/docs/visual-basic/misc/bc31082.md
+++ b/docs/visual-basic/misc/bc31082.md
@@ -1,5 +1,5 @@
 ---
-title: "'<variablename>' のローカル変数またはパラメーターではないと、'Catch' 変数として使用することはできません"
+title: "'<variablename>' はローカル変数またはパラメータでないため、'Catch' 変数として使うことはできません。"
 ms.date: 07/20/2015
 f1_keywords:
 - bc31082
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 01/30/2019
 ms.locfileid: "55264493"
 ---
-# <a name="variablename-is-not-a-local-variable-or-parameter-and-so-cannot-be-used-as-a-catch-variable"></a>'\<variablename >' のローカル変数またはパラメーターではないと、'Catch' 変数として使用することはできません
+# <a name="variablename-is-not-a-local-variable-or-parameter-and-so-cannot-be-used-as-a-catch-variable"></a>'\<variablename>' はローカル変数またはパラメータでないため、'Catch' 変数として使うことはできません。
 `Try...Catch...Finally` ステートメント内の変数は、ローカルで宣言されているか、現在のプロシージャのパラメーターである必要があります。  
   
  **エラー ID:** BC31082  


### PR DESCRIPTION
…パラメータでないため

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/misc/bc31082