### PR TITLE
'<typename >' は型であり、式として使用することはできません → '<typename>' は型であるため、式として使用するこ…

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/typename-is-a-type-and-cannot-be-used-as-an-expression.md
+++ b/docs/visual-basic/language-reference/error-messages/typename-is-a-type-and-cannot-be-used-as-an-expression.md
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 01/30/2019
 ms.locfileid: "55285143"
 ---
-# <a name="typename-is-a-type-and-cannot-be-used-as-an-expression"></a>'\<typename >' は型であるため、式として使用することはできません。
+# <a name="typename-is-a-type-and-cannot-be-used-as-an-expression"></a>'\<typename >' は型であるため、式として使用することはできません
 式が必要な個所で、型名が出現しています。 式は、変数、定数、リテラル、プロパティ、および `Function` プロシージャ呼び出しを適宜組み合わせて構成する必要があります。  
   
  **エラー ID:** BC30108  

--- a/docs/visual-basic/language-reference/error-messages/typename-is-a-type-and-cannot-be-used-as-an-expression.md
+++ b/docs/visual-basic/language-reference/error-messages/typename-is-a-type-and-cannot-be-used-as-an-expression.md
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 01/30/2019
 ms.locfileid: "55285143"
 ---
-# <a name="typename-is-a-type-and-cannot-be-used-as-an-expression"></a>'\<typename >' は型であり、式として使用することはできません
+# <a name="typename-is-a-type-and-cannot-be-used-as-an-expression"></a>'\<typename >' は型であるため、式として使用することはできません。
 式が必要な個所で、型名が出現しています。 式は、変数、定数、リテラル、プロパティ、および `Function` プロシージャ呼び出しを適宜組み合わせて構成する必要があります。  
   
  **エラー ID:** BC30108  


### PR DESCRIPTION
…とはできません。

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/typename-is-a-type-and-cannot-be-used-as-an-expression