### PR TITLE
Typo "Visual c#" → "Visual C#"

### DIFF
--- a/docs/framework/winforms/how-to-simulate-mouse-and-keyboard-events-in-code.md
+++ b/docs/framework/winforms/how-to-simulate-mouse-and-keyboard-events-in-code.md
@@ -87,7 +87,7 @@ Windows フォームは、プログラムでマウスおよびキーボード入
   
 -   System、System.Drawing、および System.Windows.Forms の各アセンブリへの参照。  
   
- コマンドラインからこの例を Visual Basic または Visual c# の構築方法の詳細については、[、コマンドラインからビルドする](../../visual-basic/reference/command-line-compiler/building-from-the-command-line.md)または[コマンド ライン ビルドで csc.exe](../../csharp/language-reference/compiler-options/command-line-building-with-csc-exe.md)を参照してください。 新しいプロジェクトにコードを貼り付けることによって、この例では、Visual Studio を構築することもできます。  
+ コマンドラインからこの例を Visual Basic または Visual C# の構築方法の詳細については、[、コマンドラインからビルドする](../../visual-basic/reference/command-line-compiler/building-from-the-command-line.md)または[コマンド ライン ビルドで csc.exe](../../csharp/language-reference/compiler-options/command-line-building-with-csc-exe.md)を参照してください。 新しいプロジェクトにコードを貼り付けることによって、この例では、Visual Studio を構築することもできます。  
   
 ## <a name="see-also"></a>関連項目
 - [Windows フォームでのユーザー入力](user-input-in-windows-forms.md)


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/framework/winforms/how-to-simulate-mouse-and-keyboard-events-in-code