### PR TITLE
[LOC] Back-Translation "<ランタイム > 要素" → "<runtime> 要素"

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element.md
@@ -18,7 +18,7 @@ ms.locfileid: "61704662"
 64 ビット プラットフォームで、合計サイズが 2 GB (ギガバイト) を超える配列を有効にします。  
   
  \<configuration > 要素  
-\<ランタイム > 要素  
+\<runtime> 要素  
 \<gcAllowVeryLargeObjects > 要素  
   
 ## <a name="syntax"></a>構文  


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element