### PR TITLE
fixed inappropriate japanese "<assemblyBinding > 要素の<ランタイム >" → "<run…

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/assemblyidentity-element-for-runtime.md
+++ b/docs/framework/configure-apps/file-schema/runtime/assemblyidentity-element-for-runtime.md
@@ -16,7 +16,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 04/23/2019
 ms.locfileid: "61674234"
 ---
-# <a name="assemblyidentity-element-for-runtime"></a>\<assemblyIdentity > 要素の\<ランタイム >
+# <a name="assemblyidentity-element-for-runtime"></a><runtime> の <assemblyIdentity> 要素
 アセンブリに関する識別情報が含まれています。  
   
  \<configuration>  


### PR DESCRIPTION
…time> の <assemblyIdentity> 要素"

https://docs.microsoft.com/ja-jp/dotnet/framework/configure-apps/file-schema/runtime/assemblybinding-element-for-runtime