### PR TITLE
不要な記号の削除

### DIFF
--- a/docs/machine-learning/toc.yml
+++ b/docs/machine-learning/toc.yml
@@ -66,7 +66,7 @@
   items:
     - name: 用語集
       href: resources/glossary.md
-    - name: '[タスク]'
+    - name: タスク
       href: resources/tasks.md
     - name: アルゴリズム
       href: how-to-choose-an-ml-net-algorithm.md


### PR DESCRIPTION
目次のタイトルに不要なシングルクォートとカッコがあったので削除しました。