### PR TITLE
fixed inappropriate japanese "方法: 定義の演算子"→"方法: 演算子を定義する"

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/procedures/how-to-define-an-operator.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/how-to-define-an-operator.md
@@ -39,7 +39,7 @@ ms.locfileid: "61863846"
 ## <a name="see-also"></a>関連項目
 
 - [演算子プロシージャ](./operator-procedures.md)
-- [方法: 変換演算子を定義します。](./how-to-define-a-conversion-operator.md)
+- [方法: 変換演算子を定義する](./how-to-define-a-conversion-operator.md)
 - [方法: 演算子プロシージャを呼び出す](./how-to-call-an-operator-procedure.md)
 - [方法: 演算子を定義するクラスを使用する](./how-to-use-a-class-that-defines-operators.md)
 - [Operator ステートメント](../../../../visual-basic/language-reference/statements/operator-statement.md)

--- a/docs/visual-basic/programming-guide/language-features/procedures/how-to-define-an-operator.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/how-to-define-an-operator.md
@@ -1,5 +1,5 @@
 ---
-title: '方法: 定義の演算子 (Visual Basic)'
+title: '方法: 演算子を定義する (Visual Basic)'
 ms.date: 07/20/2015
 helpviewer_keywords:
 - procedures [Visual Basic], defining
@@ -20,7 +20,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 04/23/2019
 ms.locfileid: "61863846"
 ---
-# <a name="how-to-define-an-operator-visual-basic"></a>方法: 定義の演算子 (Visual Basic)
+# <a name="how-to-define-an-operator-visual-basic"></a>方法: 演算子を定義する (Visual Basic)
 標準の演算子の動作を定義するクラスまたは構造体を定義している場合 (など`*`、 `<>`、または`And`) 1 つまたは両方のオペランドがクラスまたは構造体の型であるとき。  
   
  演算子プロシージャ内でクラスまたは構造体として標準の演算子を定義します。 演算子のすべてのプロシージャである必要があります`Public``Shared`します。  

--- a/docs/visual-basic/programming-guide/language-features/procedures/how-to-define-an-operator.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/how-to-define-an-operator.md
@@ -41,7 +41,7 @@ ms.locfileid: "61863846"
 - [演算子プロシージャ](./operator-procedures.md)
 - [方法: 変換演算子を定義します。](./how-to-define-a-conversion-operator.md)
 - [方法: 演算子プロシージャを呼び出す](./how-to-call-an-operator-procedure.md)
-- [方法: 演算子を定義するクラスを使用して、](./how-to-use-a-class-that-defines-operators.md)
+- [方法: 演算子を定義するクラスを使用する](./how-to-use-a-class-that-defines-operators.md)
 - [Operator ステートメント](../../../../visual-basic/language-reference/statements/operator-statement.md)
 - [Structure ステートメント](../../../../visual-basic/language-reference/statements/structure-statement.md)
 - [方法: 構造体を宣言する](../../../../visual-basic/programming-guide/language-features/data-types/how-to-declare-a-structure.md)


### PR DESCRIPTION
related:  #766

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/programming-guide/language-features/procedures/how-to-define-an-operator