### PR TITLE
fixed inappropriate japanese "プロシージャのパラメーターを定義します。"→"プロシージャにパラメーターを定義する"

### DIFF
--- a/docs/visual-basic/programming-guide/language-features/procedures/procedure-parameters-and-arguments.md
+++ b/docs/visual-basic/programming-guide/language-features/procedures/procedure-parameters-and-arguments.md
@@ -65,7 +65,7 @@ ms.locfileid: "64638834"
 - [Function プロシージャ](./function-procedures.md)
 - [Property プロシージャ](./property-procedures.md)
 - [演算子プロシージャ](./operator-procedures.md)
-- [方法: プロシージャのパラメーターを定義します。](./how-to-define-a-parameter-for-a-procedure.md)
+- [方法: プロシージャにパラメーターを定義する](./how-to-define-a-parameter-for-a-procedure.md)
 - [方法: プロシージャに引数を渡す](./how-to-pass-arguments-to-a-procedure.md)
 - [引数の値渡しと参照渡し](./passing-arguments-by-value-and-by-reference.md)
 - [プロシージャのオーバーロード](./procedure-overloading.md)


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/programming-guide/language-features/procedures/procedure-parameters-and-arguments