### PR TITLE
[LOC] Back-Translation "<ランタイム >"→"<runtime>"

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element.md
@@ -21,8 +21,8 @@ ms.locfileid: "70252871"
 <xref:System.AppContext> クラスで使用される、新機能に対するオプトアウト メカニズムを指定するスイッチを 1 つまたは複数定義します。  
   
 [ **\<configuration>** ](../configuration-element.md)\
-&nbsp;&nbsp;[ **\<ランタイム >** ](runtime-element.md)\
-&nbsp;&nbsp;&nbsp;&nbsp; **\<AppContextSwitchOverrides >**  
+&nbsp;&nbsp;[ **\<runtime>** ](runtime-element.md)\
+&nbsp;&nbsp;&nbsp;&nbsp; **\<AppContextSwitchOverrides>**  
   
 ## <a name="syntax"></a>構文  
   


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/framework/configure-apps/file-schema/runtime/appcontextswitchoverrides-element