### PR TITLE
[LOC] Back-Translation "<ランタイム >"→"<runtime>"

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/appdomainmanagerassembly-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/appdomainmanagerassembly-element.md
@@ -18,7 +18,7 @@ ms.locfileid: "70252847"
 プロセスにおける既定のアプリケーション ドメインのアプリケーション ドメイン マネージャーを提供するアセンブリを指定します。  
   
 [ **\<configuration>** ](../configuration-element.md)\
-&nbsp;&nbsp;[ **\<ランタイム >** ](runtime-element.md)\
+&nbsp;&nbsp;[ **\<runtime>** ](runtime-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp; **\<appDomainManagerAssembly>**  
   
 ## <a name="syntax"></a>構文  
@@ -77,7 +77,7 @@ ms.locfileid: "70252847"
 
 - <xref:System.AppDomainSetup.AppDomainManagerType%2A?displayProperty=nameWithType>
 - <xref:System.AppDomainSetup.AppDomainManagerAssembly%2A?displayProperty=nameWithType>
-- [\<appDomainManagerType > 要素](appdomainmanagertype-element.md)
+- [\<appDomainManagerType> 要素](appdomainmanagertype-element.md)
 - [ランタイム設定スキーマ](index.md)
 - [構成ファイル スキーマ](../index.md)
 - [SetAppDomainManagerType メソッド](../../../unmanaged-api/hosting/iclrcontrol-setappdomainmanagertype-method.md)


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/framework/configure-apps/file-schema/runtime/appdomainmanagerassembly-element