### PR TITLE
[LOC] Back-Translation "<ランタイム >"→"<runtime>"

### DIFF
--- a/docs/framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element.md
+++ b/docs/framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element.md
@@ -14,11 +14,11 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 09/04/2019
 ms.locfileid: "70252581"
 ---
-# <a name="gcallowverylargeobjects-element"></a>\<gcAllowVeryLargeObjects > 要素
+# <a name="gcallowverylargeobjects-element"></a>\<gcAllowVeryLargeObjects> 要素
 64 ビット プラットフォームで、合計サイズが 2 GB (ギガバイト) を超える配列を有効にします。  
   
 [ **\<configuration>** ](../configuration-element.md)\
-&nbsp;&nbsp;[ **\<ランタイム >** ](runtime-element.md)\
+&nbsp;&nbsp;[ **\<runtime>** ](runtime-element.md)\
 &nbsp;&nbsp;&nbsp;&nbsp; **\<gcAllowVeryLargeObjects>**  
   
 ## <a name="syntax"></a>構文  


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/framework/configure-apps/file-schema/runtime/gcallowverylargeobjects-element