### PR TITLE
[LOC]fixed inappropriate japanese "<eventname >' は、イベントで、"→"'<eventna…

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/eventname-is-an-event-and-cannot-be-called-directly.md
+++ b/docs/visual-basic/language-reference/error-messages/eventname-is-an-event-and-cannot-be-called-directly.md
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 04/23/2019
 ms.locfileid: "61803323"
 ---
-# <a name="eventname-is-an-event-and-cannot-be-called-directly"></a>'\<eventname >' は、イベントで、直接呼び出すことはできません
+# <a name="eventname-is-an-event-and-cannot-be-called-directly"></a>'\<eventname>' はイベントであるため、直接呼び出すことはできません
 ' <`eventname`>' は、イベントで、これは直接呼び出すことができません。 使用して、`RaiseEvent`イベントを発生させるステートメントです。  
   
  プロシージャ呼び出しでは、イベント プロシージャ名を指定します。 イベント ハンドラーは、プロシージャが、イベント自体はシグナル デバイスで発生して処理する必要がありますが、です。  


### PR DESCRIPTION
…me>' はイベントであるため、"

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/eventname-is-an-event-and-cannot-be-called-directly

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
