### PR TITLE
[LOC] Back-Translation "'<式>'型制約"→"'<expression>' を型制約"

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/expression-cannot-be-used-as-a-type-constraint.md
+++ b/docs/visual-basic/language-reference/error-messages/expression-cannot-be-used-as-a-type-constraint.md
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 04/28/2019
 ms.locfileid: "64642797"
 ---
-# <a name="expression-cannot-be-used-as-a-type-constraint"></a>'\<式 >' を型制約として使用することはできません
+# <a name="expression-cannot-be-used-as-a-type-constraint"></a>'\<expression>' を型制約として使用することはできません。
 制約リストに、型パラメーターについて有効な制約を表していない式が含まれています。  
   
  制約リストでは、型パラメーターに渡される型引数の要件が適用されます。 次の要件を任意の組み合わせで指定できます。  


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/expression-cannot-be-used-as-a-type-constraint

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
