### PR TITLE
[LOC]fixed inappropriate japanese "<functionname >' が宣言されていません"→"<fun…

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/functionname-is-not-declared-smart-device-visual-basic-compiler-error.md
+++ b/docs/visual-basic/language-reference/error-messages/functionname-is-not-declared-smart-device-visual-basic-compiler-error.md
@@ -1,5 +1,5 @@
 ---
-title: "'<functionname>' (Smart Device/visual Basic コンパイラ エラー) が宣言されていません"
+title: "'<functionname>' は宣言されていません (スマート デバイスおよび Visual Basic コンパイラ エラー)"
 ms.date: 07/20/2015
 f1_keywords:
 - bc30766
@@ -14,8 +14,8 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 04/28/2019
 ms.locfileid: "64662086"
 ---
-# <a name="functionname-is-not-declared-smart-devicevisual-basic-compiler-error"></a>'\<functionname >' (Smart Device/visual Basic コンパイラ エラー) が宣言されていません
-<`functionname`> が宣言されていません。 通常、ファイル I/O 機能は `Microsoft.VisualBasic` 名前空間で使用できますが、.NET Compact Framework のターゲット バージョンではサポートされていません。  
+# <a name="functionname-is-not-declared-smart-devicevisual-basic-compiler-error"></a>'\<functionname >' は宣言されていません (スマート デバイスおよび Visual Basic コンパイラ エラー)
+<`functionname`> は宣言されていません。 通常、ファイル I/O 機能は `Microsoft.VisualBasic` 名前空間で使用できますが、.NET Compact Framework のターゲット バージョンではサポートされていません。  
   
  **エラー ID:** BC30766  
   


### PR DESCRIPTION
…ctionname >' は宣言されていません"

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/functionname-is-not-declared-smart-device-visual-basic-compiler-error

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
