### PR TITLE
Typo "[Visual Basic のアクセスレベル]"→"[Visual Basic でのアクセス レベル]"

### DIFF
--- a/docs/visual-basic/language-reference/statements/declaration-contexts-and-default-access-levels.md
+++ b/docs/visual-basic/language-reference/statements/declaration-contexts-and-default-access-levels.md
@@ -49,7 +49,7 @@ ms.locfileid: "74354103"
 |イベント ([Event ステートメント](../../../visual-basic/language-reference/statements/event-statement.md))|使用不可|`Public`|使用不可|  
 |デリゲート ([Delegate ステートメント](../../../visual-basic/language-reference/statements/delegate-statement.md))|`Friend`|`Public`|使用不可|  
   
- 詳細については、「[Visual Basic のアクセスレベル](../../../visual-basic/programming-guide/language-features/declared-elements/access-levels.md)」を参照してください。  
+ 詳細については、「[Visual Basic でのアクセス レベル](../../../visual-basic/programming-guide/language-features/declared-elements/access-levels.md)」を参照してください。  
   
 ## <a name="see-also"></a>参照
 


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/statements/declaration-contexts-and-default-access-levels

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
