### PR TITLE
[LOC]Fixed inappropriate japanese "\<演算子 >'"→"演算子'\<operator>'"

### DIFF
--- a/docs/visual-basic/misc/bc33038.md
+++ b/docs/visual-basic/misc/bc33038.md
@@ -1,5 +1,5 @@
 ---
-title: 型 '<typename>'演算子を定義する必要があります'<operator>'、'For' ステートメントで使用するには
+title: 型 '<typename>' を 'For' ステートメントで使用するには、演算子'<operator>' を定義しなければなりません。
 ms.date: 07/20/2015
 f1_keywords:
 - vbc33038
@@ -14,8 +14,8 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 04/28/2019
 ms.locfileid: "64626579"
 ---
-# <a name="type-typename-must-define-operator-operator-to-be-used-in-a-for-statement"></a>型 '\<typename >' 演算子を定義する必要があります'\<演算子 >'、'For' ステートメントで使用するには
-`For` ループが、必要な演算子をサポートしていない型のカウンター変数を指定しています。  
+# <a name="type-typename-must-define-operator-operator-to-be-used-in-a-for-statement"></a>型 '\<typename>' を 'For' ステートメントで使用するには、演算子'\<operator>' を定義しなければなりません。
+  `For` ループが、必要な演算子をサポートしていない型のカウンター変数を指定しています。  
   
  `For` ループ内のカウンター変数は、次の演算子のすべてをサポートする任意のデータ型にすることができます。  
   
@@ -46,6 +46,6 @@ ms.locfileid: "64626579"
 - [For...Next ステートメント](../../visual-basic/language-reference/statements/for-next-statement.md)
 - [演算子プロシージャ](../../visual-basic/programming-guide/language-features/procedures/operator-procedures.md)
 - [Operator ステートメント](../../visual-basic/language-reference/statements/operator-statement.md)
-- [方法: 演算子を定義します。](../../visual-basic/programming-guide/language-features/procedures/how-to-define-an-operator.md)
-- [方法: 変換演算子を定義します。](../../visual-basic/programming-guide/language-features/procedures/how-to-define-a-conversion-operator.md)
+- [方法 : 演算子を定義する](../../visual-basic/programming-guide/language-features/procedures/how-to-define-an-operator.md)
+- [方法 : 変換演算子を定義する](../../visual-basic/programming-guide/language-features/procedures/how-to-define-a-conversion-operator.md)
 - [CType 関数](../../visual-basic/language-reference/functions/ctype-function.md)


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/misc/bc33038

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
