### PR TITLE
Typo "[Visual Basic のアクセスレベル]"→"[Visual Basic でのアクセス レベル]"

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/membername-cannot-expose-type-typename-outside-the-project.md
+++ b/docs/visual-basic/language-reference/error-messages/membername-cannot-expose-type-typename-outside-the-project.md
@@ -1,5 +1,5 @@
 ---
-title: "'<membername>' は、型 '<typename>' を <containertype> '<containertypename>' 経由でプロジェクトの外側に公開できません。"
+title: "'<membername>' は、型 '<typename>' を <containertype>'<containertypename>' 経由でプロジェクトの外側に公開できません。"
 ms.date: 07/20/2015
 f1_keywords:
 - bc30909
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 10/01/2019
 ms.locfileid: "71700897"
 ---
-# <a name="membername-cannot-expose-type-typename-outside-the-project-through-containertype-containertypename"></a>'\<membername > ' は \<containertype > '\<containertypename > ' 経由でプロジェクト外部の型 '\<typename > ' を公開できません
+# <a name="membername-cannot-expose-type-typename-outside-the-project-through-containertype-containertypename"></a>'\<membername>' は、型 '\<typename>' を \<containertype>'\<containertypename>' 経由でプロジェクトの外側に公開できません。
 変数、プロシージャパラメーター、または関数の戻り値は、コンテナーの外部に公開されますが、コンテナーの外部に公開されてはならない型として宣言されています。  
   
  次のスケルトンコードは、このエラーを生成する状況を示しています。  
@@ -37,4 +37,4 @@ End Class
   
 ## <a name="see-also"></a>参照
 
-- [Visual Basic のアクセスレベル](../../../visual-basic/programming-guide/language-features/declared-elements/access-levels.md)
+- [Visual Basic でのアクセス レベル](../../../visual-basic/programming-guide/language-features/declared-elements/access-levels.md)


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/membername-cannot-expose-type-typename-outside-the-project

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
