### PR TITLE
[LOC]fixed inappropriate japanese "「宣言された[要素名]"→"[宣言された要素の名前]"

### DIFF
--- a/docs/visual-basic/language-reference/statements/enum-statement.md
+++ b/docs/visual-basic/language-reference/statements/enum-statement.md
@@ -61,7 +61,7 @@ End Enum
 
 - `enumerationname`
 
-  必須。 列挙体の名前。 有効な名前の詳細については、「宣言された[要素名](../../../visual-basic/programming-guide/language-features/declared-elements/declared-element-names.md)」を参照してください。
+  必須。 列挙体の名前。 有効な名前の詳細については、「[宣言された要素の名前](../../../visual-basic/programming-guide/language-features/declared-elements/declared-element-names.md)」を参照してください。
 
 - `datatype`
 


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/statements/enum-statement

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
