### PR TITLE
[LOC]Fixed inappropriate japanese "関数の型を返す～"→"関数 '<procedurename>' の戻…

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/return-type-of-function-procedurename-is-not-cls-compliant.md
+++ b/docs/visual-basic/language-reference/error-messages/return-type-of-function-procedurename-is-not-cls-compliant.md
@@ -14,7 +14,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 05/15/2019
 ms.locfileid: "65642255"
 ---
-# <a name="return-type-of-function-procedurename-is-not-cls-compliant"></a>関数の型を返す '\<procedurename >' は CLS 準拠
+# <a name="return-type-of-function-procedurename-is-not-cls-compliant"></a>関数 '\<procedurename >' の戻り値の型は CLS に準拠していません。
 A`Function`プロシージャがマーク`<CLSCompliant(True)>`としてマークされている型を返しますが、 `<CLSCompliant(False)>`、マークされていない、または非準拠の型であるためには修飾されません。  
   
  プロシージャを[言語への非依存性および言語非依存コンポーネント](../../../standard/language-independence-and-language-independent-components.md) (CLS) に準拠させるには、CLS 準拠型のみを使用する必要があります。 これは、パラメーターの型、戻り値の型、およびすべてのローカル変数の型に適用されます。  


### PR DESCRIPTION
…り値の型～"

https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/return-type-of-function-procedurename-is-not-cls-compliant

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
