### PR TITLE
[LOC]Fixed inappropriate japanese "[入れ子になったコントロール構造]"→"[入れ子になった制御構造]"

### DIFF
--- a/docs/visual-basic/language-reference/statements/for-each-next-statement.md
+++ b/docs/visual-basic/language-reference/statements/for-each-next-statement.md
@@ -80,13 +80,13 @@ Next [ element ]
 
 ループを入れ子にする場合、各ループには一意の `element` 変数が必要です。
 
-また、さまざまな種類の制御構造を相互に入れ子にすることもできます。 詳細については、「[入れ子になったコントロール構造](../../../visual-basic/programming-guide/language-features/control-flow/nested-control-structures.md)」を参照してください。
+また、さまざまな種類の制御構造を相互に入れ子にすることもできます。 詳細については、「[入れ子になった制御構造](../../../visual-basic/programming-guide/language-features/control-flow/nested-control-structures.md)」を参照してください。
 
 ## <a name="exit-for-and-continue-for"></a>Exit For と Continue For
 
 [Exit For](../../../visual-basic/language-reference/statements/exit-statement.md)ステートメントを実行すると、`For`...`Next` が終了します ループし、`Next` ステートメントの後のステートメントに制御を転送します。
 
-`Continue For` ステートメントは、ループの次の反復処理に制御を直ちに転送します。 詳細については、「 [Continue ステートメント](../../../visual-basic/language-reference/statements/continue-statement.md)」を参照してください。
+`Continue For` ステートメントは、ループの次の反復処理に制御を直ちに転送します。 詳細については、「[Continue ステートメント](../../../visual-basic/language-reference/statements/continue-statement.md)」を参照してください。
 
 次の例では、`Continue For` ステートメントと `Exit For` ステートメントを使用する方法を示します。
 
@@ -100,7 +100,7 @@ Next [ element ]
 
 - 例外は、`Try`...`Catch`...`Finally`でキャッチされます。`Finally` ブロックの末尾に `Exit For` を使用することもできます。
 
-- 無限ループがあります。これは、大規模または無限の回数実行されるループです。 このような条件を検出した場合は、`Exit For` を使用してループをエスケープできます。 詳細については、「 [Do...Loop ステートメント](../../../visual-basic/language-reference/statements/do-loop-statement.md)。
+- 無限ループがあります。これは、大規模または無限の回数実行されるループです。 このような条件を検出した場合は、`Exit For` を使用してループをエスケープできます。 詳細については、「[Do...Loop ステートメント](../../../visual-basic/language-reference/statements/do-loop-statement.md)」を参照してください。
 
 ## <a name="iterators"></a>反復子
 


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/statements/for-each-next-statement

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
