### PR TITLE
[LOC]Fixed inappropriate japanese "インターフェイス型である\<ため、"→"インターフェイス型であるため、"

### DIFF
--- a/docs/visual-basic/language-reference/error-messages/latebound-overload-resolution-cannot-be-applied.md
+++ b/docs/visual-basic/language-reference/error-messages/latebound-overload-resolution-cannot-be-applied.md
@@ -15,8 +15,8 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 07/26/2019
 ms.locfileid: "68513026"
 ---
-# <a name="latebound-overload-resolution-cannot-be-applied-to-procedurename-because-the-accessing-instance-is-an-interface-type"></a>アクセスするインスタンスがインターフェイス型であるため、遅延バインドされたオーバーロードの解決は '\<procedurename>' に適用されません。
-
+# <a name="latebound-overload-resolution-cannot-be-applied-to-procedurename-because-the-accessing-instance-is-an-interface-type"></a>アクセスするインスタンスがインターフェイス型であるため、遅延バインドされたオーバーロードの解決は '\<procedurename>' に適用されません
+  
 コンパイラは、オーバーロードされたプロパティまたはプロシージャへの参照を解決しようとしていますが、引数`Object`が型であり、参照元のオブジェクトがインターフェイスのデータ型を持っているため、参照は失敗します。 引数`Object`は、コンパイラが参照を遅延バインディングとして解決することを強制します。
 
 このような場合、コンパイラは、基になるインターフェイスを使用するのではなく、実装するクラスを使用してオーバーロードを解決します。 クラスがオーバーロードされたバージョンの1つの名前を変更した場合、コンパイラはそのバージョンの名前が異なるため、そのバージョンがオーバーロードであるとは見なされません。 これにより、コンパイラは、参照を解決するための正しい選択が行われている可能性がある場合に、名前が変更されたバージョンを無視します。

--- a/docs/visual-basic/language-reference/error-messages/latebound-overload-resolution-cannot-be-applied.md
+++ b/docs/visual-basic/language-reference/error-messages/latebound-overload-resolution-cannot-be-applied.md
@@ -15,7 +15,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 07/26/2019
 ms.locfileid: "68513026"
 ---
-# <a name="latebound-overload-resolution-cannot-be-applied-to-procedurename-because-the-accessing-instance-is-an-interface-type"></a>アクセスするインスタンスがインターフェイス型である\<ため、遅延バインディングされたオーバーロードの解決は ' procedurename > ' に適用できません
+# <a name="latebound-overload-resolution-cannot-be-applied-to-procedurename-because-the-accessing-instance-is-an-interface-type"></a>アクセスするインスタンスがインターフェイス型であるため、遅延バインドされたオーバーロードの解決は '\<procedurename>' に適用されません。
 
 コンパイラは、オーバーロードされたプロパティまたはプロシージャへの参照を解決しようとしていますが、引数`Object`が型であり、参照元のオブジェクトがインターフェイスのデータ型を持っているため、参照は失敗します。 引数`Object`は、コンパイラが参照を遅延バインディングとして解決することを強制します。
 


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/language-reference/error-messages/latebound-overload-resolution-cannot-be-applied

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
