### PR TITLE
Typo "`-reference` の省略形は `/r`"→"`-reference` の省略形は -r`"

### DIFF
--- a/docs/visual-basic/reference/command-line-compiler/reference.md
+++ b/docs/visual-basic/reference/command-line-compiler/reference.md
@@ -52,7 +52,7 @@ ms.locfileid: "74348592"
   
  Vbc.exe ファイルは、一般的に使用される .NET Framework アセンブリを参照します。既定では、このファイルが使用されます。 コンパイラで Vbc.exe を使用しない場合は、`-noconfig` を使用します。  
   
- `-reference` の省略形は `/r` です。  
+ `-reference` の省略形は `-r` です。  
   
 ## <a name="example"></a>例  
  次のコマンドは、`Metad1.dll` と `Metad2.dll` からソースファイル `Input.vb` と参照アセンブリをコンパイルして `Out.exe`を生成します。  


### PR DESCRIPTION
https://docs.microsoft.com/ja-jp/dotnet/visual-basic/reference/command-line-compiler/reference

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
