### PR TITLE
[LOC]Fixed inappropriate japanese "`result` の値はです。"→"`result` の値"

### DIFF
--- a/docs/visual-basic/language-reference/operators/and-operator.md
+++ b/docs/visual-basic/language-reference/operators/and-operator.md
@@ -42,7 +42,7 @@ result = expression1 And expression2
 ## <a name="remarks"></a>コメント  
  ブール値の比較では、`expression1` と `expression2` の両方が `True`に評価される場合にのみ、`result` が `True` ます。 次の表は、`result` がどのように決定されるかを示しています。  
   
-|`expression1` の場合|`expression2`|`result` の値はです。|  
+|`expression1` の値|`expression2` の値|`result` の値|  
 |-------------------------|--------------------------|------------------------------|  
 |`True`|`True`|`True`|  
 |`True`|`False`|`False`|  


### PR DESCRIPTION
https://docs.microsoft.com/ja-JP/dotnet/visual-basic/language-reference/operators/and-operator

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
