### PR TITLE
Replace dash (–) used where hyphen (-) should have been used.

### DIFF
--- a/docs/visual-basic/language-reference/keywords/derived-math-functions.md
+++ b/docs/visual-basic/language-reference/keywords/derived-math-functions.md
@@ -38,7 +38,7 @@ ms.locfileid: "84373890"
 |Cotangent (Ctan(x))|1 / Tan(x)|  
 |Inverse sine (Asin(x))|Atan(x / Sqrt(-x * x + 1))|  
 |Inverse cosine (Acos(x))|Atan(-x / Sqrt(-x * x + 1)) + 2 \* Atan(1)|  
-|Inverse secant (Asec(x))|2 * Atan(1) - Atan(Sign(x) / Sqrt(x \* x – 1))|  
+|Inverse secant (Asec(x))|2 * Atan(1) - Atan(Sign(x) / Sqrt(x \* x - 1))|  
 |Inverse cosecant (Acsc(x))|Atan(Sign(x) / Sqrt(x * x - 1))|  
 |Inverse cotangent (Acot(x))|2 * Atan(1) - Atan(x)|  
 |Hyperbolic sine (Sinh(x))|(Exp(x) - Exp(-x)) / 2|  

--- a/docs/visual-basic/language-reference/keywords/derived-math-functions.md
+++ b/docs/visual-basic/language-reference/keywords/derived-math-functions.md
@@ -38,21 +38,21 @@ ms.locfileid: "84373890"
 |Cotangent (Ctan(x))|1 / Tan(x)|  
 |Inverse sine (Asin(x))|Atan(x / Sqrt(-x * x + 1))|  
 |Inverse cosine (Acos(x))|Atan(-x / Sqrt(-x * x + 1)) + 2 \* Atan(1)|  
-|Inverse secant (Asec(x))|2 * Atan(1) – Atan(Sign(x) / Sqrt(x \* x – 1))|  
-|Inverse cosecant (Acsc(x))|Atan(Sign(x) / Sqrt(x * x – 1))|  
+|Inverse secant (Asec(x))|2 * Atan(1) - Atan(Sign(x) / Sqrt(x \* x – 1))|  
+|Inverse cosecant (Acsc(x))|Atan(Sign(x) / Sqrt(x * x - 1))|  
 |Inverse cotangent (Acot(x))|2 * Atan(1) - Atan(x)|  
-|Hyperbolic sine (Sinh(x))|(Exp(x) – Exp(-x)) / 2|  
+|Hyperbolic sine (Sinh(x))|(Exp(x) - Exp(-x)) / 2|  
 |Hyperbolic cosine (Cosh(x))|(Exp(x) + Exp(-x)) / 2|  
-|Hyperbolic tangent (Tanh(x))|(Exp(x) – Exp(-x)) / (Exp(x) + Exp(-x))|  
+|Hyperbolic tangent (Tanh(x))|(Exp(x) - Exp(-x)) / (Exp(x) + Exp(-x))|  
 |Hyperbolic secant (Sech(x))|2 / (Exp(x) + Exp(-x))|  
-|Hyperbolic cosecant (Csch(x))|2 / (Exp(x) – Exp(-x))|  
-|Hyperbolic cotangent (Coth(x))|(Exp(x) + Exp(-x)) / (Exp(x) – Exp(-x))|  
+|Hyperbolic cosecant (Csch(x))|2 / (Exp(x) - Exp(-x))|  
+|Hyperbolic cotangent (Coth(x))|(Exp(x) + Exp(-x)) / (Exp(x) - Exp(-x))|  
 |Inverse hyperbolic sine (Asinh(x))|Log(x + Sqrt(x * x + 1))|  
-|Inverse hyperbolic cosine (Acosh(x))|Log(x + Sqrt(x * x – 1))|  
-|Inverse hyperbolic tangent (Atanh(x))|Log((1 + x) / (1 – x)) / 2|  
+|Inverse hyperbolic cosine (Acosh(x))|Log(x + Sqrt(x * x - 1))|  
+|Inverse hyperbolic tangent (Atanh(x))|Log((1 + x) / (1 - x)) / 2|  
 |Inverse hyperbolic secant (AsecH(x))|Log((Sqrt(-x * x + 1) + 1) / x)|  
 |Inverse hyperbolic cosecant (Acsch(x))|Log((Sign(x) * Sqrt(x \* x + 1) + 1) / x)|  
-|Inverse hyperbolic cotangent (Acoth(x))|Log((x + 1) / (x – 1)) / 2|  
+|Inverse hyperbolic cotangent (Acoth(x))|Log((x + 1) / (x - 1)) / 2|  
   
 ## <a name="see-also"></a>関連項目
 


### PR DESCRIPTION
Replace dash (–) used where hyphen (-) should have been used.

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
