### PR TITLE
Fix "explicit"

### DIFF
--- a/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
+++ b/docs/csharp/programming-guide/inside-a-program/coding-conventions.md
@@ -105,7 +105,7 @@ ms.locfileid: "79398377"
 
 - [foreach](../../language-reference/keywords/foreach-in.md) ループでループ変数の型を決定するときは、暗黙の型指定は使用されません。
 
-     次の例では、`foreach` ステートメントで暗黙の型指定が使用されています。
+     次の例では、`foreach` ステートメントで明示的な型指定が使用されています。
 
      [!code-csharp[csProgGuideCodingConventions#12](../../../../samples/snippets/csharp/VS_Snippets_VBCSharp/csprogguidecodingconventions/cs/program.cs#12)]
 


### PR DESCRIPTION
|original|before|after|
|-|-|-|
|The following example uses **explicit** typing in a `foreach` statement.|次の例では、`foreach` ステートメントで **暗黙の** 型指定が使用されています。|次の例では、`foreach` ステートメントで **明示的な** 型指定が使用されています。|